### PR TITLE
Fix typo: mertic -> metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,27 @@ Uses the `APPOPTICS_TOKEN` environment variable.
 ### Send a single measurement
 
 ```elixir
-  iex> AppOptex.measurement("my.mertic", 10, %{my_tag: "value"})
+  iex> AppOptex.measurement("my.metric", 10, %{my_tag: "value"})
   :ok
-  iex> AppOptex.measurement(%{name: "my.mertic", value: 10}, %{my_tag: "value"})
+  iex> AppOptex.measurement(%{name: "my.metric", value: 10}, %{my_tag: "value"})
   :ok
 ```
 
 ### Send multiple measurements
 
 ```elixir
-  iex> AppOptex.measurements([%{name: "my.mertic", value: 1}, %{name: "my.other_mertic", value: 5}], %{my_tag: "value"})
+  iex> AppOptex.measurements([%{name: "my.metric", value: 1}, %{name: "my.other_metric", value: 5}], %{my_tag: "value"})
   :ok
 ```
 
 ### Read metrics
 
 ```elixir
-  iex> AppOptex.read_measurements("my.mertic", 60, %{duration: 86400})
+  iex> AppOptex.read_measurements("my.metric", 60, %{duration: 86400})
   %{
     "attributes" => %{"created_by_ua" => "hackney/1.15.1"},
     "links" => [],
-    "name" => "my.mertic",
+    "name" => "my.metric",
     "resolution" => 60,
     "series" => [
       %{

--- a/lib/app_optex.ex
+++ b/lib/app_optex.ex
@@ -14,7 +14,7 @@ defmodule AppOptex do
 
   ## Examples
 
-      iex> AppOptex.measurement("my.mertic", 10, %{my_tag: "value"})
+      iex> AppOptex.measurement("my.metric", 10, %{my_tag: "value"})
       :ok
 
   """
@@ -34,7 +34,7 @@ defmodule AppOptex do
 
   ## Examples
 
-      iex> AppOptex.measurement(%{name: "my.mertic", value: 10}, %{my_tag: "value"})
+      iex> AppOptex.measurement(%{name: "my.metric", value: 10}, %{my_tag: "value"})
       :ok
 
   """
@@ -50,7 +50,7 @@ defmodule AppOptex do
 
   ## Examples
 
-      iex> AppOptex.measurements([%{name: "my.mertic", value: 1}, %{name: "my.other_mertic", value: 5}], %{my_tag: "value"})
+      iex> AppOptex.measurements([%{name: "my.metric", value: 1}, %{name: "my.other_metric", value: 5}], %{my_tag: "value"})
       :ok
 
   """
@@ -69,11 +69,11 @@ defmodule AppOptex do
     - `duration` - How far back to look in time, measured in seconds. This parameter can be used in combination with endtime to set a starttime N seconds back in time. It is an error to set starttime, endtime and duration.
 
   ## Examples
-      iex> AppOptex.client.read_measurements("my.other_mertic", 60, %{duration: 999999})
+      iex> AppOptex.client.read_measurements("my.other_metric", 60, %{duration: 999999})
       %{
         "attributes" => %{"created_by_ua" => "hackney/1.15.1"},
         "links" => [],
-        "name" => "my.other_mertic",
+        "name" => "my.other_metric",
         "resolution" => 60,
         "series" => [
           %{

--- a/lib/app_optex/client.ex
+++ b/lib/app_optex/client.ex
@@ -47,11 +47,11 @@ defmodule AppOptex.Client do
 
   ## Examples
 
-      iex> AppOptex.Client.read_measurements("https://api.appoptics.com/v1/measurements", "MY_TOKEN", "my.other_mertic", 60, %{duration: 999999})
+      iex> AppOptex.Client.read_measurements("https://api.appoptics.com/v1/measurements", "MY_TOKEN", "my.other_metric", 60, %{duration: 999999})
       %{
             "attributes" => %{"created_by_ua" => "hackney/1.15.1"},
             "links" => [],
-            "name" => "my.other_mertic",
+            "name" => "my.other_metric",
             "resolution" => 60,
             "series" => [
                 %{
@@ -63,25 +63,25 @@ defmodule AppOptex.Client do
 
   """
 
-  def read_measurements(appoptics_url, token, mertic_name, resolution, %{start_time: _} = params),
-    do: _read_measurements(appoptics_url, token, mertic_name, resolution, params)
+  def read_measurements(appoptics_url, token, metric_name, resolution, %{start_time: _} = params),
+    do: _read_measurements(appoptics_url, token, metric_name, resolution, params)
 
-  def read_measurements(appoptics_url, token, mertic_name, resolution, %{duration: _} = params),
-    do: _read_measurements(appoptics_url, token, mertic_name, resolution, params)
+  def read_measurements(appoptics_url, token, metric_name, resolution, %{duration: _} = params),
+    do: _read_measurements(appoptics_url, token, metric_name, resolution, params)
 
   def read_measurements(
         appoptics_url,
         token,
-        mertic_name,
+        metric_name,
         resolution,
         %{duration: _, start_time: _} = params
       ),
-      do: _read_measurements(appoptics_url, token, mertic_name, resolution, params)
+      do: _read_measurements(appoptics_url, token, metric_name, resolution, params)
 
-  def read_measurements(_appoptics_url, _token, _mertic_name, _resolution, _),
+  def read_measurements(_appoptics_url, _token, _metric_name, _resolution, _),
     do: raise("Must provide either :duration or :start_time")
 
-  def _read_measurements(appoptics_url, token, mertic_name, resolution, params)
+  def _read_measurements(appoptics_url, token, metric_name, resolution, params)
       when is_map(params) do
     query =
       params
@@ -90,7 +90,7 @@ defmodule AppOptex.Client do
       |> Enum.join("&")
 
     HTTPoison.get!(
-      "#{appoptics_url}/#{mertic_name}?#{query}",
+      "#{appoptics_url}/#{metric_name}?#{query}",
       [{"Content-Type", "application/json"}],
       hackney: [basic_auth: {token, ""}]
     )


### PR DESCRIPTION
Simple typo fix. mertic to metric